### PR TITLE
Fixed missing semicolon

### DIFF
--- a/myohw.h
+++ b/myohw.h
@@ -74,7 +74,7 @@ typedef enum{
     BatteryLevelCharacteristic    = 0x2a19, ///< Current battery level information. Read/notify characteristic.
 
     DeviceName                    = 0x2a00, ///< Device name data. Read/write characteristic.
-} myohw_standard_services
+} myohw_standard_services;
 
 /// Supported poses.
 typedef enum {


### PR DESCRIPTION
myohw_standard_services was missing a semicolon.
